### PR TITLE
Fix a bug in tracking

### DIFF
--- a/boremeter/extract_people.py
+++ b/boremeter/extract_people.py
@@ -48,6 +48,7 @@ def extract_faces(video_file_path, frames_limit, tmp_dir, detection_step):
             max_id += 1
 
         for new_id, new_bbox in new_bboxes_by_id.iteritems():
+            print "new_id", new_id,
             face_found = False
             for old_id, old_bbox in old_bboxes_by_id.iteritems():
                 if timeouts[old_id] > 0:
@@ -56,10 +57,12 @@ def extract_faces(video_file_path, frames_limit, tmp_dir, detection_step):
                         timeouts[old_id] = initial_timeout
                         face_found = True
                         face_ids_to_delete.append(new_id)
-                    elif have_intersection(old_bbox, new_bbox):
+                    elif not face_found and have_intersection(old_bbox, new_bbox):
                         face_ids_to_delete.append(new_id)
-
+                        face_found = True
+        print '\n', face_ids_to_delete
         for face_id in face_ids_to_delete:
+            print face_id,
             del new_bboxes_by_id[face_id]
 
         for tracked_face in tracked_faces:

--- a/boremeter/extract_people.py
+++ b/boremeter/extract_people.py
@@ -48,7 +48,6 @@ def extract_faces(video_file_path, frames_limit, tmp_dir, detection_step):
             max_id += 1
 
         for new_id, new_bbox in new_bboxes_by_id.iteritems():
-            print "new_id", new_id,
             face_found = False
             for old_id, old_bbox in old_bboxes_by_id.iteritems():
                 if timeouts[old_id] > 0:
@@ -60,7 +59,6 @@ def extract_faces(video_file_path, frames_limit, tmp_dir, detection_step):
                     elif not face_found and have_intersection(old_bbox, new_bbox):
                         face_ids_to_delete.append(new_id)
                         face_found = True
-        print '\n', face_ids_to_delete
         for face_id in face_ids_to_delete:
             print face_id,
             del new_bboxes_by_id[face_id]

--- a/boremeter/extract_people.py
+++ b/boremeter/extract_people.py
@@ -59,8 +59,8 @@ def extract_faces(video_file_path, frames_limit, tmp_dir, detection_step):
                     elif not face_found and have_intersection(old_bbox, new_bbox):
                         face_ids_to_delete.append(new_id)
                         face_found = True
+
         for face_id in face_ids_to_delete:
-            print face_id,
             del new_bboxes_by_id[face_id]
 
         for tracked_face in tracked_faces:


### PR DESCRIPTION
Если несколько old_bboxes имели пересечение с new_bbox, то new_id удалялось повторно из new_bboxes_by_id, вызывая KeyError